### PR TITLE
feat(projects): Ordena projetos do GitHub por data de push

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -114,11 +114,10 @@
                 pagination.appendChild(next);
             }
 
-            fetch('https://api.github.com/users/guilhermeportella/repos')
+            fetch('https://api.github.com/users/guilhermeportella/repos?sort=pushed&per_page=100')
                 .then(response => response.json())
                 .then(data => {
                     repos = Array.isArray(data) ? data : [];
-                    repos.sort((a, b) => new Date(b.updated_at) - new Date(a.updated_at));
                     totalPages = Math.ceil(repos.length / PROJECTS_PER_PAGE);
                     renderPage(currentPage);
                 })


### PR DESCRIPTION
A chamada à API do GitHub para buscar os repositórios não especificava uma ordem, resultando na ordenação padrão por data de criação. Isso causava uma inconsistência com a ordem de "última atualização" exibida no perfil do GitHub.

Esta alteração ajusta a requisição `fetch` para utilizar o parâmetro `sort=pushed`, instruindo a API a retornar os repositórios já ordenados pela data do último push (do mais recente para o mais antigo).

Adicionalmente, o parâmetro `per_page=100` foi incluído para garantir que mais de 30 repositórios sejam retornados, e a lógica de ordenação manual no lado do cliente (JavaScript) foi removida por ser redundante.